### PR TITLE
PoE+++++ページの追加

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,13 @@
 		%sveltekit.head%
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+			integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -109,6 +109,11 @@
 						<h3 class="inline-block">UniPostor</h3>
 					</a>
 				</div>
+				<div class="poe-plus pb-3 pt-5">
+					<a href="/create/poe_plus_plus_plus_plus_plus">
+						<h3>PoE+++++</h3>
+					</a>
+				</div>
 			</div>
 		</div>
 

--- a/src/routes/create/poe_plus_plus_plus_plus_plus/+page.svelte
+++ b/src/routes/create/poe_plus_plus_plus_plus_plus/+page.svelte
@@ -1,0 +1,66 @@
+<div class="container mx-auto max-w-4xl px-4 py-8">
+	<h1 class="mb-6 text-3xl font-bold">Power over Ethernet +++++</h1>
+
+	<div class="prose mb-8 max-w-none">
+		<p>LANケーブルを使って電力を供給するPoE。</p>
+		<p>でも今の時代その程度で足りますか？足りませんよね</p>
+		<p>ということで100vで流せるようにしておきました。</p>
+		<p>(PoEで100vは実在しません)</p>
+	</div>
+
+	<div class="mb-8">
+		<h2 class="mb-4 text-2xl font-bold">Links</h2>
+
+		<div class="mb-6">
+			<img
+				src="https://pbs.twimg.com/media/GtKVo2tbMAA0Lfl?format=jpg&name=4096x4096"
+				alt="画像"
+				class="h-auto max-w-full rounded-lg shadow-lg"
+			/>
+		</div>
+
+		<div class="mb-4">
+			<a
+				href="https://x.com/uesitananame55/status/1932771723914719349"
+				class="break-all text-blue-600 hover:underline"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				https://x.com/uesitananame55/status/1932771723914719349
+			</a>
+		</div>
+
+		<div class="mb-6">
+			<h3 class="mb-2 text-xl font-bold">Booth</h3>
+			<a
+				href="https://zin3.booth.pm/"
+				class="text-blue-600 hover:underline"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				https://zin3.booth.pm/
+			</a>
+		</div>
+
+		<div class="mb-8">
+			<h3 class="mb-2 text-xl font-bold">SUZURI</h3>
+			<a
+				href="https://suzuri.jp/zin3/products"
+				class="text-blue-600 hover:underline"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				https://suzuri.jp/zin3/products
+			</a>
+		</div>
+	</div>
+
+	<div class="mt-8">
+		<a
+			href="/"
+			class="inline-block rounded-lg bg-gray-800 px-6 py-3 text-white transition-colors hover:bg-gray-700"
+		>
+			トップへ戻る
+		</a>
+	</div>
+</div>

--- a/src/routes/create/poe_plus_plus_plus_plus_plus/page.test.ts
+++ b/src/routes/create/poe_plus_plus_plus_plus_plus/page.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+
+describe('PoE+++++ page', () => {
+	it('should have the correct title', () => {
+		render(Page);
+
+		const title = screen.getByRole('heading', { name: 'Power over Ethernet +++++', level: 1 });
+		expect(title).toBeInTheDocument();
+	});
+
+	it('should have description text', () => {
+		render(Page);
+
+		expect(screen.getByText(/LANケーブルを使って電力を供給するPoE/)).toBeInTheDocument();
+		expect(
+			screen.getByText(/でも今の時代その程度で足りますか？足りませんよね/)
+		).toBeInTheDocument();
+		expect(screen.getByText(/ということで100vで流せるようにしておきました/)).toBeInTheDocument();
+		expect(screen.getByText(/\(PoEで100vは実在しません\)/)).toBeInTheDocument();
+	});
+
+	it('should have Links heading', () => {
+		render(Page);
+
+		const linksHeading = screen.getByRole('heading', { name: 'Links', level: 2 });
+		expect(linksHeading).toBeInTheDocument();
+	});
+
+	it('should have image with correct src', () => {
+		render(Page);
+
+		const image = screen.getByAltText('画像');
+		expect(image).toBeInTheDocument();
+		expect(image).toHaveAttribute(
+			'src',
+			'https://pbs.twimg.com/media/GtKVo2tbMAA0Lfl?format=jpg&name=4096x4096'
+		);
+	});
+
+	it('should have X (Twitter) link', () => {
+		render(Page);
+
+		const xLink = screen.getByRole('link', {
+			name: 'https://x.com/uesitananame55/status/1932771723914719349'
+		});
+		expect(xLink).toBeInTheDocument();
+		expect(xLink).toHaveAttribute(
+			'href',
+			'https://x.com/uesitananame55/status/1932771723914719349'
+		);
+	});
+
+	it('should have Booth section and link', () => {
+		render(Page);
+
+		const boothHeading = screen.getByRole('heading', { name: 'Booth', level: 3 });
+		expect(boothHeading).toBeInTheDocument();
+
+		const boothLink = screen.getByRole('link', { name: 'https://zin3.booth.pm/' });
+		expect(boothLink).toBeInTheDocument();
+		expect(boothLink).toHaveAttribute('href', 'https://zin3.booth.pm/');
+	});
+
+	it('should have SUZURI section and link', () => {
+		render(Page);
+
+		const suzuriHeading = screen.getByRole('heading', { name: 'SUZURI', level: 3 });
+		expect(suzuriHeading).toBeInTheDocument();
+
+		const suzuriLink = screen.getByRole('link', { name: 'https://suzuri.jp/zin3/products' });
+		expect(suzuriLink).toBeInTheDocument();
+		expect(suzuriLink).toHaveAttribute('href', 'https://suzuri.jp/zin3/products');
+	});
+
+	it('should have back to top link', () => {
+		render(Page);
+
+		const backLink = screen.getByRole('link', { name: 'トップへ戻る' });
+		expect(backLink).toBeInTheDocument();
+		expect(backLink).toHaveAttribute('href', '/');
+	});
+});

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -47,4 +47,12 @@ describe('+page.svelte', () => {
 		const playStoreIcon = link.querySelector('i.fa-google-play, i.fab.fa-google-play');
 		expect(playStoreIcon).toBeTruthy();
 	});
+
+	it('should have PoE+++++ link in Create section', () => {
+		render(Page);
+
+		const link = screen.getByRole('link', { name: 'PoE+++++' });
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute('href', '/create/poe_plus_plus_plus_plus_plus');
+	});
 });

--- a/src/style.css
+++ b/src/style.css
@@ -79,3 +79,11 @@
 .unipostor a {
 	color: white;
 }
+
+.poe-plus {
+	background-color: #ff9500;
+}
+
+.poe-plus a {
+	color: white;
+}


### PR DESCRIPTION
## 概要
issue #3 の対応として、CreateセクションにPoE+++++ページを追加しました。

## 変更内容
### 新機能
- 🆕 `/create/poe_plus_plus_plus_plus_plus` ページの追加
  - Power over Ethernet +++++の説明ページ
  - LANケーブルで100v電力供給する架空製品の紹介
  - 画像表示とX（Twitter）投稿へのリンク
  - BoothとSUZURIの販売ページへのリンク
  - トップページへの戻るボタン

### UI変更
- 🎨 トップページのCreateセクションにPoE+++++リンクを追加
- 🎨 PoE+++++用の背景色（#ff9500）とテキスト色（白）を設定

### テスト
- ✅ PoE+++++ページの表示テストを追加（8項目）
- ✅ トップページのテストを更新（PoE+++++リンクの確認を追加）

## テスト計画
- [x] `npm run test` で全テストが通ることを確認
- [x] `npm run lint` でコードフォーマットを確認
- [x] `npm run check` で型チェックを確認
- [ ] ブラウザでページの表示を確認
- [ ] 各リンクが正しく動作することを確認
- [ ] レスポンシブデザインの確認

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)