### PR TITLE
Createセクションにドメイン一覧リンクを追加

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -114,6 +114,11 @@
 						<h3>PoE+++++</h3>
 					</a>
 				</div>
+				<div class="domain-list pb-3 pt-5">
+					<a href="https://domains.zin3.cc/">
+						<h3>ドメイン一覧</h3>
+					</a>
+				</div>
 			</div>
 		</div>
 

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -55,4 +55,12 @@ describe('+page.svelte', () => {
 		expect(link).toBeInTheDocument();
 		expect(link).toHaveAttribute('href', '/create/poe_plus_plus_plus_plus_plus');
 	});
+
+	it('should have ドメイン一覧 link in Create section', () => {
+		render(Page);
+
+		const link = screen.getByRole('link', { name: 'ドメイン一覧' });
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute('href', 'https://domains.zin3.cc/');
+	});
 });

--- a/src/style.css
+++ b/src/style.css
@@ -87,3 +87,11 @@
 .poe-plus a {
 	color: white;
 }
+
+.domain-list {
+	background-color: #3553e8;
+}
+
+.domain-list a {
+	color: white;
+}


### PR DESCRIPTION
## 概要
Issue #7 の対応として、トップページのCreateセクションに「ドメイン一覧」リンクを追加しました。

## 変更内容
- `src/routes/+page.svelte`にドメイン一覧リンクを追加
- `src/style.css`に`.domain-list`クラスのスタイルを追加
  - 背景色: #3553e8
  - テキスト色: white
- リンク先: https://domains.zin3.cc/
- テストケースを追加してリンクの存在とhref属性を検証

## テスト計画
- [x] Playwrightでドメイン一覧リンクが正しく表示されることを確認
- [x] 背景色が#3553e8（rgb(53, 83, 232)）であることを確認
- [x] リンク先が https://domains.zin3.cc/ であることを確認
- [x] すべてのテストが成功することを確認

## スクリーンショット
Playwrightで以下を確認しました：
- ドメイン一覧リンクが表示されている
- 背景色が正しく適用されている
- リンク先が正しく設定されている

## 関連Issue
Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)